### PR TITLE
Let nested:get/3 return the default correctly

### DIFF
--- a/src/nested.erl
+++ b/src/nested.erl
@@ -28,7 +28,12 @@ get([], Value) ->
     Value.
 
 get([Key|PathRest], Map, Default) ->
-    get(PathRest, maps:get(Key, Map, Default), Default);
+    case maps:get(Key, Map, {?MODULE, Default}) of
+        {?MODULE, Default} ->
+            Default;
+        NestedMap ->
+            get(PathRest, NestedMap, Default)
+    end;
 
 get([], Value, _) ->
     Value.


### PR DESCRIPTION
Previously calls to `nested:get([...], Map, Default)` would fail if `Default` is not a map itself.
